### PR TITLE
feat: add public analytics link to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -25,6 +25,15 @@ const year = new Date().getFullYear();
     </p>
 
     <p class="font-mono text-xs text-zinc-400 dark:text-zinc-600">
+      <a
+        href="https://cloud.umami.is/analytics/eu/share/oFVqOmBoVR0LhsPp"
+        target="_blank"
+        rel="noopener"
+        class="text-zinc-500 dark:text-zinc-500 hover:text-[var(--color-brand-dark)] transition-colors"
+      >
+        Analytics
+      </a>
+      {" · "}
       {t("footer.built")}
       <a
         href="https://astro.build"


### PR DESCRIPTION
Closes #5

## Summary

- Added "Analytics" link in footer pointing to the public Umami dashboard
- Visitors can see site traffic stats transparently without logging in

## Test plan

- [ ] Footer shows "Analytics" link
- [ ] Link opens the public Umami dashboard