### PR TITLE
feat: add RSS feed links and browser language detection redirect

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,6 +26,13 @@ const year = new Date().getFullYear();
 
     <p class="font-mono text-xs text-zinc-400 dark:text-zinc-600">
       <a
+        href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}
+        class="text-zinc-500 dark:text-zinc-500 hover:text-[var(--color-brand-dark)] transition-colors"
+      >
+        RSS
+      </a>
+      {" · "}
+      <a
         href="https://cloud.umami.is/analytics/eu/share/oFVqOmBoVR0LhsPp"
         target="_blank"
         rel="noopener"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -71,7 +71,18 @@ const currentPath = Astro.url.pathname;
       </nav>
       <div class="w-px h-4 bg-zinc-200 dark:bg-white/10 mx-1"></div>
       <a
+        href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}
+        class="p-1.5 rounded-md text-zinc-400 dark:text-zinc-500 hover:text-[var(--color-brand-dark)] hover:bg-zinc-100/80 dark:hover:bg-white/[0.05] transition-all"
+        title="RSS Feed"
+      >
+        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="6.18" cy="17.82" r="2.18"></circle>
+          <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"></path>
+        </svg>
+      </a>
+      <a
         href={alternatePath}
+        data-lang-switch={lang === "sk" ? "en" : "sk"}
         class="px-3 py-1.5 rounded-md text-xs font-mono font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100/80 dark:hover:bg-white/[0.05] transition-all"
         title={t("lang.switch")}
       >
@@ -209,11 +220,23 @@ const currentPath = Astro.url.pathname;
     }
   </nav>
 
-  <!-- Bottom: lang switch -->
-  <div class="px-5 pb-28 pt-4 border-t border-white/[0.06] shrink-0">
+  <!-- Bottom: RSS + lang switch -->
+  <div class="px-5 pb-28 pt-4 border-t border-white/[0.06] shrink-0 flex gap-3">
+    <a
+      href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}
+      class="fab-nav-link flex items-center justify-center gap-2 py-3.5 px-4 rounded-xl border border-white/10 text-sm font-mono font-medium text-zinc-400 hover:text-white hover:border-white/20 transition-all active:scale-[0.98]"
+      title="RSS Feed"
+    >
+      <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+        <circle cx="6.18" cy="17.82" r="2.18"></circle>
+        <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"></path>
+      </svg>
+      RSS
+    </a>
     <a
       href={alternatePath}
-      class="fab-nav-link flex items-center justify-center gap-2 w-full py-3.5 rounded-xl border border-white/10 text-sm font-mono font-medium text-zinc-400 hover:text-white hover:border-white/20 transition-all active:scale-[0.98]"
+      data-lang-switch={lang === "sk" ? "en" : "sk"}
+      class="fab-nav-link flex-1 flex items-center justify-center gap-2 py-3.5 rounded-xl border border-white/10 text-sm font-mono font-medium text-zinc-400 hover:text-white hover:border-white/20 transition-all active:scale-[0.98]"
     >
       <svg
         class="w-3.5 h-3.5"
@@ -323,5 +346,13 @@ const currentPath = Astro.url.pathname;
 
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape" && isOpen) closeMenu();
+  });
+
+  // Remember manual language choice
+  document.querySelectorAll("[data-lang-switch]").forEach((link) => {
+    link.addEventListener("click", () => {
+      const target = (link as HTMLElement).dataset.langSwitch;
+      if (target) localStorage.setItem("langChosen", target);
+    });
   });
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -79,6 +79,23 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
         }
       })();
     </script>
+
+    <!-- Language redirect: detect browser lang on first visit -->
+    <script is:inline>
+      (function () {
+        if (localStorage.getItem("langChosen")) return;
+        var path = window.location.pathname;
+        var isRoot = path === "/" || path === "/index.html";
+        if (!isRoot) return;
+        var browserLang = (navigator.language || "").slice(0, 2).toLowerCase();
+        if (browserLang === "sk") {
+          localStorage.setItem("langChosen", "sk");
+        } else {
+          localStorage.setItem("langChosen", "en");
+          window.location.replace("/en");
+        }
+      })();
+    </script>
   </head>
   <body class="min-h-screen flex flex-col">
     <canvas id="bg-canvas" class="fixed inset-0 -z-10 pointer-events-none"


### PR DESCRIPTION
## Summary
- RSS feed links added to footer, desktop header (icon), and mobile menu (button) — URL switches based on current language (`/rss.xml` vs `/en/rss.xml`)
- Client-side browser language detection on first visit to `/` — SK browsers stay, all others redirect to `/en`
- Manual language switch saves preference to `localStorage`, preventing future automatic redirects

## Test plan
- [x] Verify RSS icon visible in desktop header next to lang switcher
- [x] Verify RSS button visible in mobile menu next to lang switch
- [ ] Verify RSS link in footer, before Analytics
- [x] Switch to EN — confirm RSS links point to `/en/rss.xml`
- [x] Clear `localStorage`, set browser to EN — confirm redirect to `/en`
- [x] Clear `localStorage`, set browser to SK — confirm stays on `/`
- [x] Switch language manually, reload — confirm no redirect happens

Closes #12