### PR TITLE
fix: improve light mode readability and mobile menu theming

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,7 +30,7 @@ const currentPath = Astro.url.pathname;
 
 <!-- ── Desktop header (hidden on mobile) ───────────────────── -->
 <header
-  class="hidden sm:block sticky top-0 z-50 border-b border-zinc-200/60 dark:border-white/[0.06] bg-[#f8f9fb]/80 dark:bg-[#080c12]/80 backdrop-blur-md"
+  class="hidden sm:block sticky top-0 z-50 border-b border-zinc-200/60 dark:border-white/[0.06] bg-[#f8f9fb]/95 dark:bg-[#080c12]/80 backdrop-blur-md"
 >
   <div
     class="max-w-4xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between"
@@ -131,16 +131,15 @@ const currentPath = Astro.url.pathname;
 <!-- ── Full-screen mobile overlay ──────────────────────────── -->
 <div
   id="fab-overlay"
-  class="sm:hidden fixed inset-0 z-40 flex flex-col pointer-events-none opacity-0"
-  style="background: rgba(8, 12, 18, 0.97); backdrop-filter: blur(20px);"
+  class="sm:hidden fixed inset-0 z-40 flex flex-col pointer-events-none opacity-0 bg-[#f8f9fb] dark:bg-[#080c12] backdrop-blur-2xl"
 >
   <!-- Top bar: logo + theme toggle -->
   <div
-    class="flex items-center justify-between px-6 h-16 border-b border-white/[0.06] shrink-0"
+    class="flex items-center justify-between px-6 h-16 border-b border-zinc-200/60 dark:border-white/[0.06] shrink-0"
   >
     <a
       href={prefix || "/"}
-      class="fab-nav-link font-mono font-semibold text-base text-white/90 tracking-tight"
+      class="fab-nav-link font-mono font-semibold text-base text-zinc-900 dark:text-white/90 tracking-tight"
     >
       rebjak<span
         class="text-transparent bg-clip-text"
@@ -151,7 +150,7 @@ const currentPath = Astro.url.pathname;
 
     <button
       id="fab-theme-toggle"
-      class="p-2.5 rounded-xl border border-white/10 text-zinc-400 hover:text-white hover:border-white/20 transition-all"
+      class="p-2.5 rounded-xl border border-zinc-200 dark:border-white/10 text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white hover:border-zinc-300 dark:hover:border-white/20 transition-all"
       aria-label="Toggle theme"
     >
       <svg
@@ -197,13 +196,13 @@ const currentPath = Astro.url.pathname;
             href={href}
             class:list={[
               "fab-nav-link flex items-center px-4 py-4 rounded-2xl transition-all duration-150 active:scale-[0.98]",
-              isActive ? "bg-white/[0.07]" : "hover:bg-white/[0.04]",
+              isActive ? "bg-zinc-200/60 dark:bg-white/[0.07]" : "hover:bg-zinc-100 dark:hover:bg-white/[0.04]",
             ]}
           >
             <span
               class:list={[
                 "text-2xl font-bold font-mono tracking-tight",
-                isActive ? "text-white" : "text-zinc-500",
+                isActive ? "text-zinc-900 dark:text-white" : "text-zinc-400 dark:text-zinc-500",
               ]}
             >
               {label}
@@ -221,10 +220,10 @@ const currentPath = Astro.url.pathname;
   </nav>
 
   <!-- Bottom: RSS + lang switch -->
-  <div class="px-5 pb-28 pt-4 border-t border-white/[0.06] shrink-0 flex gap-3">
+  <div class="px-5 pb-28 pt-4 border-t border-zinc-200/60 dark:border-white/[0.06] shrink-0 flex gap-3">
     <a
       href={lang === "en" ? "/en/rss.xml" : "/rss.xml"}
-      class="fab-nav-link flex items-center justify-center gap-2 py-3.5 px-4 rounded-xl border border-white/10 text-sm font-mono font-medium text-zinc-400 hover:text-white hover:border-white/20 transition-all active:scale-[0.98]"
+      class="fab-nav-link flex items-center justify-center gap-2 py-3.5 px-4 rounded-xl border border-zinc-200 dark:border-white/10 text-sm font-mono font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white hover:border-zinc-300 dark:hover:border-white/20 transition-all active:scale-[0.98]"
       title="RSS Feed"
     >
       <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
@@ -236,7 +235,7 @@ const currentPath = Astro.url.pathname;
     <a
       href={alternatePath}
       data-lang-switch={lang === "sk" ? "en" : "sk"}
-      class="fab-nav-link flex-1 flex items-center justify-center gap-2 py-3.5 rounded-xl border border-white/10 text-sm font-mono font-medium text-zinc-400 hover:text-white hover:border-white/20 transition-all active:scale-[0.98]"
+      class="fab-nav-link flex-1 flex items-center justify-center gap-2 py-3.5 rounded-xl border border-zinc-200 dark:border-white/10 text-sm font-mono font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white hover:border-zinc-300 dark:hover:border-white/20 transition-all active:scale-[0.98]"
     >
       <svg
         class="w-3.5 h-3.5"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -98,7 +98,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
     </script>
   </head>
   <body class="min-h-screen flex flex-col">
-    <canvas id="bg-canvas" class="fixed inset-0 -z-10 pointer-events-none"
+    <canvas id="bg-canvas" class="hidden sm:block fixed inset-0 -z-10 pointer-events-none"
     ></canvas>
     <Header lang={lang} alternatePath={alternatePath} />
     <main class="flex-1">
@@ -176,7 +176,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 
               const proximity = 1 - dist / CONNECT_DIST;
               const depthFade = (a.depth + b.depth) / 2;
-              const baseAlpha = dark ? 0.1 : 0.45;
+              const baseAlpha = dark ? 0.1 : 0.3;
               const alpha = proximity * depthFade * baseAlpha;
 
               // gradient line: colour of A → colour of B
@@ -202,7 +202,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
             const mdist = Math.sqrt(mdx * mdx + mdy * mdy);
             if (mdist < MOUSE_DIST) {
               const t = 1 - mdist / MOUSE_DIST;
-              const mAlpha = t * a.depth * (dark ? 0.6 : 1.0);
+              const mAlpha = t * a.depth * (dark ? 0.6 : 0.65);
               const grad = ctx.createLinearGradient(a.x, a.y, mouse.x, mouse.y);
               grad.addColorStop(0, `rgba(${ca},${mAlpha})`);
               grad.addColorStop(1, `rgba(${ca},0)`);
@@ -224,7 +224,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
             const near = mdist < MOUSE_DIST;
             const mt = near ? 1 - mdist / MOUSE_DIST : 0;
 
-            const baseA = dark ? 0.18 : 0.55;
+            const baseA = dark ? 0.18 : 0.38;
             const alpha = (baseA + mt * 0.75) * p.depth;
             const radius = 1.2 + p.depth * 1.2 + mt * 2;
 
@@ -240,7 +240,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
               );
               glow.addColorStop(
                 0,
-                `rgba(${col},${mt * (dark ? 0.35 : 0.6) * p.depth})`,
+                `rgba(${col},${mt * (dark ? 0.35 : 0.4) * p.depth})`,
               );
               glow.addColorStop(1, `rgba(${col},0)`);
               ctx.fillStyle = glow;


### PR DESCRIPTION
## Summary
- Reduce particle canvas alpha values on light mode for better text contrast
- Add proper light/dark mode support to mobile overlay menu (background, text, borders, buttons)
- Hide canvas on mobile (`hidden sm:block`) — no mouse interaction there anyway
- Increase desktop header background opacity on light mode (`/80` → `/95`)

Closes #14