### PR TITLE
feat: add release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,60 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: 'Features'
+    labels:
+      - 'feat'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'docs'
+      - 'test'
+
+autolabeler:
+  - label: 'feat'
+    title:
+      - '/^feat(\(.+\))?[!]?:/'
+  - label: 'fix'
+    title:
+      - '/^fix(\(.+\))?[!]?:/'
+  - label: 'chore'
+    title:
+      - '/^chore(\(.+\))?[!]?:/'
+  - label: 'refactor'
+    title:
+      - '/^refactor(\(.+\))?[!]?:/'
+  - label: 'docs'
+    title:
+      - '/^docs(\(.+\))?[!]?:/'
+  - label: 'test'
+    title:
+      - '/^test(\(.+\))?[!]?:/'
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'feat'
+  patch:
+    labels:
+      - 'fix'
+      - 'chore'
+      - 'refactor'
+      - 'docs'
+      - 'test'
+  default: patch
+
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `release-drafter/release-drafter@v6` workflow triggered on push to main and PR events
- Add `.github/release-drafter.yml` config with autolabeler for conventional commits (feat/fix/chore/refactor/docs/test)
- Groups PRs into Features / Bug Fixes / Maintenance categories
- Version resolver: feat → minor, fix/chore → patch

Closes #18