### PR TITLE
feat(seo): add hreflang alternate links

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,7 +2,7 @@
 import "../styles/global.css";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
-import { getLangFromUrl, useTranslations } from "../i18n/translations";
+import { getLangFromUrl, getAlternatePath, useTranslations } from "../i18n/translations";
 
 interface Props {
   title: string;
@@ -22,6 +22,10 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+const altLang = lang === "sk" ? "en" : "sk";
+const altPath = alternatePath ?? getAlternatePath(Astro.url, altLang);
+const skUrl = new URL(lang === "sk" ? Astro.url.pathname : altPath, Astro.site);
+const enUrl = new URL(lang === "en" ? Astro.url.pathname : altPath, Astro.site);
 ---
 
 <!doctype html>
@@ -34,6 +38,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
     <title>{title} — rebjak.com</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Hreflang -->
+    <link rel="alternate" hreflang="sk" href={skUrl} />
+    <link rel="alternate" hreflang="en" href={enUrl} />
+    <link rel="alternate" hreflang="x-default" href={skUrl} />
 
     <!-- Open Graph -->
     <meta property="og:title" content={`${title} — rebjak.com`} />


### PR DESCRIPTION
## Summary

- Add `<link rel="alternate" hreflang="sk|en|x-default">` to all pages via BaseLayout
- Uses existing `getAlternatePath()` to auto-compute the alternate language URL
- Verified in build output: SK pages point to EN counterpart and vice versa

Closes #26