### PR TITLE
feat(blog): add PageSpeed optimization post (#43)

### DIFF
--- a/src/content/en/blog/pagespeed-optimization.md
+++ b/src/content/en/blog/pagespeed-optimization.md
@@ -2,8 +2,8 @@
 title: 'PageSpeed optimization and GitHub Pages limitations'
 description: 'Lighthouse showed Performance 87 on mobile. Self-hosted fonts, WCAG contrast, trailing slash — and why GitHub Pages cache headers prevent reaching 100. Building in public, part four.'
 pubDate: 2026-03-08T10:00:00
-tags: ['astro', 'performance', 'building-in-public']
-draft: true
+tags: ['astro', 'performance', 'github-pages', 'building-in-public']
+draft: false
 ---
 
 The site has SEO at 100, Best Practices at 100 — but Performance at 87 and Accessibility at 94. Lighthouse clearly showed what needed fixing.
@@ -19,55 +19,80 @@ After running [PageSpeed Insights](https://pagespeed.web.dev/) on `rebjak.com/en
 | Best Practices | 100 |
 | SEO | 100 |
 
-Four main issues:
+Three main issues:
 
-1. **Render-blocking Google Fonts** — ~2000 ms savings available
-2. **Insufficient color contrast** — WCAG AA failure
+1. **Google Fonts** — render-blocking + external requests, ~2000 ms savings available
+2. **Insufficient color contrast** — WCAG AA failure in both dark and light mode
 3. **Trailing slash redirect** — `/en` → `/en/` costs ~925 ms
-4. **External font requests** — DNS + TLS handshake on every visit
 
-## 1. Render-blocking fonts
+## 1. Google Fonts → self-hosting
 
 ### Problem
 
 A standard `<link rel="stylesheet">` for Google Fonts blocks rendering of the entire page until the font CSS is downloaded. On slower connections, that means a white screen for an extra 1-2 seconds.
 
+Even if you fix the render-blocking with `preload`, fonts are still downloaded from external servers (`fonts.googleapis.com`, `fonts.gstatic.com`). Each external request means:
+
+- **DNS lookup** — the browser needs to resolve the domain to an IP address
+- **TCP + TLS handshake** — a new connection for each server
+- **No control over caching** — Google sets its own cache headers
+
+On mobile (simulated slow 4G with 150 ms RTT), this adds hundreds of milliseconds on every first load.
+
+Google Fonts serves Inter as a variable font weighing **230 KB** and JetBrains Mono at **56 KB** — totaling **286 KB** over external servers.
+
 ### Solution
 
-First step — I replaced the render-blocking link with a non-blocking `preload` + `onload` swap pattern:
+I downloaded the fonts and subsetted them using `pyftsubset` (from the `fonttools` library) to Latin + Latin Extended-A (U+0000-017F) — covering both English and Slovak (č, š, ž, ľ, ď, ť, ň and more).
 
-```html
-<!-- Before: render-blocking -->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter..." />
-
-<!-- After: non-blocking -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  rel="preload"
-  as="style"
-  href="https://fonts.googleapis.com/css2?family=Inter..."
-  onload="this.onload=null;this.rel='stylesheet'"
-/>
-<noscript>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter..." />
-</noscript>
+```bash
+pyftsubset inter-latin.woff2 \
+  --output-file=inter-latin.woff2 \
+  --flavor=woff2 \
+  --layout-features='kern,liga,clig,calt' \
+  --unicodes="U+0000-017F,U+2000-206F,U+20AC"
 ```
 
-How it works:
+The resulting sizes:
 
-- `preload` downloads the CSS in the background without blocking render
-- `onload` switches `rel` to `stylesheet` after download, applying the fonts
-- `this.onload=null` prevents repeated calls
-- `<noscript>` provides a fallback when JavaScript is disabled
+| Font | Before (Google) | After (subset) | Savings |
+|------|----------------|----------------|---------|
+| Inter | 230 KB | 45 KB | –80% |
+| JetBrains Mono | 56 KB | 32 KB | –43% |
+| **Total** | **286 KB** | **77 KB** | **–73%** |
 
-<div class="callout note">
+In `global.css`, I added `@font-face` declarations:
 
-**preconnect** opens a TCP + TLS connection to the font server before the browser even knows it will need the fonts. This saves ~100-200 ms on the first request.
+```css
+@font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400 700;
+    font-display: swap;
+    src: url('/fonts/inter-latin.woff2') format('woff2');
+    unicode-range: U+0000-017F, U+2000-206F, U+20AC;
+}
+```
+
+And in `BaseLayout.astro`, I replaced all Google Fonts links with simple `preload` declarations:
+
+```html
+<!-- Before: 4 links to external servers -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?..." onload="..." />
+<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?..." /></noscript>
+
+<!-- After: 2 preload links to own server -->
+<link rel="preload" as="font" type="font/woff2" href="/fonts/inter-latin.woff2" crossorigin />
+<link rel="preload" as="font" type="font/woff2" href="/fonts/jetbrains-mono-latin.woff2" crossorigin />
+```
+
+<div class="callout tip">
+
+**font-display: swap** shows text immediately with a fallback font (system-ui) and switches to Inter/JetBrains Mono once loaded. The user sees content right away — the font swap happens without noticeable flashing.
 
 </div>
-
-This fixed the render-blocking issue, but fonts were still being downloaded from external servers. I'll come back to that in section 4.
 
 ## 2. Color contrast (WCAG)
 
@@ -155,73 +180,6 @@ Same for dynamic links:
 
 In total, I updated links across 12 files — homepages, blog lists, tag pages, slug pages, and the Header component navigation.
 
-## 4. Self-hosting fonts
-
-### Problem
-
-Even after the preload optimization, fonts were still being downloaded from `fonts.googleapis.com` and `fonts.gstatic.com`. Each external request means:
-
-- **DNS lookup** — the browser needs to resolve the domain to an IP address
-- **TCP + TLS handshake** — a new connection for each server
-- **No control over caching** — Google sets its own cache headers
-
-On mobile (simulated slow 4G with 150 ms RTT), this adds hundreds of milliseconds on every first load.
-
-Google Fonts serves Inter as a variable font weighing **230 KB** and JetBrains Mono at **56 KB** — totaling **286 KB** over external servers.
-
-### Solution
-
-I downloaded the fonts and subsetted them using `pyftsubset` (from the `fonttools` library) to Latin + Latin Extended-A (U+0000-017F) — covering both English and Slovak (č, š, ž, ľ, ď, ť, ň and more).
-
-```bash
-pyftsubset inter-latin.woff2 \
-  --output-file=inter-latin.woff2 \
-  --flavor=woff2 \
-  --layout-features='kern,liga,clig,calt' \
-  --unicodes="U+0000-017F,U+2000-206F,U+20AC"
-```
-
-The resulting sizes:
-
-| Font | Before (Google) | After (subset) | Savings |
-|------|----------------|----------------|---------|
-| Inter | 230 KB | 45 KB | –80% |
-| JetBrains Mono | 56 KB | 32 KB | –43% |
-| **Total** | **286 KB** | **77 KB** | **–73%** |
-
-In `global.css`, I added `@font-face` declarations:
-
-```css
-@font-face {
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 400 700;
-    font-display: swap;
-    src: url('/fonts/inter-latin.woff2') format('woff2');
-    unicode-range: U+0000-017F, U+2000-206F, U+20AC;
-}
-```
-
-And in `BaseLayout.astro`, I replaced all Google Fonts links with simple `preload` declarations:
-
-```html
-<!-- Before: 4 links to external servers -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?..." onload="..." />
-<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?..." /></noscript>
-
-<!-- After: 2 preload links to own server -->
-<link rel="preload" as="font" type="font/woff2" href="/fonts/inter-latin.woff2" crossorigin />
-<link rel="preload" as="font" type="font/woff2" href="/fonts/jetbrains-mono-latin.woff2" crossorigin />
-```
-
-<div class="callout tip">
-
-**font-display: swap** shows text immediately with a fallback font (system-ui) and switches to Inter/JetBrains Mono once loaded. The user sees content right away — the font swap happens without noticeable flashing.
-
-</div>
-
 ## Result
 
 <details>
@@ -253,21 +211,21 @@ npx lighthouse http://localhost:4444/en/ \
 
 A local 100 isn't the full story. Lighthouse on the production server tests with real network latency — and the mobile preset simulates **slow 4G** (1.6 Mbps, 150 ms RTT).
 
-Before self-hosting fonts, production looked like this:
+Before optimization:
 
 | Preset | Performance | Accessibility | Best Practices | SEO |
 |--------|-------------|---------------|----------------|-----|
-| Desktop | 97 | 100 | 100 | 100 |
-| Mobile | 87 | 100 | 100 | 100 |
+| Desktop | 97 | 94 | 100 | 100 |
+| Mobile | 87 | 94 | 100 | 100 |
 
-After self-hosting and subsetting:
+After all optimizations:
 
 | Preset | Performance | Accessibility | Best Practices | SEO |
 |--------|-------------|---------------|----------------|-----|
-| Desktop | **100** | 100 | 100 | 100 |
-| Mobile | **94–95** | 100 | 100 | 100 |
+| Desktop | **100** | **100** | 100 | 100 |
+| Mobile | **94–95** | **100** | 100 | 100 |
 
-Desktop is at **100**. Mobile jumped from 87 to **94–95** — FCP dropped from 3.0 s to 1.0 s. That's a massive improvement, but still not 100. Why?
+Desktop is at **100/100/100/100**. Mobile Performance jumped from 87 to **94–95** — FCP dropped from 3.0 s to 1.0 s. Accessibility from 94 to **100**.
 
 ## Why mobile isn't 100 in production
 
@@ -304,7 +262,6 @@ These are the factors costing the remaining 5–6 points. On localhost (zero lat
 | Self-hosting fonts | Eliminates 3 external requests | Done |
 | Font subsetting | –73% font size (286 → 77 KB) | Done |
 | Trailing slash fix | Eliminates 301 redirect (~925 ms) | Done |
-| Non-blocking font loading | Eliminates render-blocking CSS | Done |
 | WCAG contrast (dark + light) | 100% Accessibility | Done |
 | CDN (Cloudflare/Vercel) | Edge caching, longer cache, Brotli | Consider |
 | Inline critical CSS | Eliminates render-blocking Astro CSS | Consider |

--- a/src/content/sk/blog/pagespeed-optimalizacia.md
+++ b/src/content/sk/blog/pagespeed-optimalizacia.md
@@ -2,8 +2,8 @@
 title: 'PageSpeed optimalizácia a limity GitHub Pages'
 description: 'Lighthouse ukázal Performance 87 na mobile. Self-hosting fontov, WCAG kontrast, trailing slash — a prečo GitHub Pages cache hlavičky bránia dosiahnuť 100. Building in public, štvrtý diel.'
 pubDate: 2026-03-08T10:00:00
-tags: ['astro', 'performance', 'building-in-public']
-draft: true
+tags: ['astro', 'performance', 'github-pages', 'building-in-public']
+draft: false
 ---
 
 Web má SEO na 100, Best Practices na 100 — ale Performance 87 a Accessibility 94. Lighthouse jasne ukázal, čo treba opraviť.
@@ -19,55 +19,80 @@ Po spustení [PageSpeed Insights](https://pagespeed.web.dev/) na `rebjak.com/en`
 | Best Practices | 100 |
 | SEO | 100 |
 
-Štyri hlavné problémy:
+Tri hlavné problémy:
 
-1. **Render-blocking Google Fonts** — ušetriteľných ~2000 ms
-2. **Nedostatočný farebný kontrast** — WCAG AA zlyhanie
+1. **Google Fonts** — render-blocking + externé requesty, ušetriteľných ~2000 ms
+2. **Nedostatočný farebný kontrast** — WCAG AA zlyhanie v dark aj light mode
 3. **Trailing slash redirect** — `/en` → `/en/` stojí ~925 ms
-4. **Externé font requesty** — DNS + TLS handshake na každý návštev
 
-## 1. Render-blocking fonty
+## 1. Google Fonts → self-hosting
 
 ### Problém
 
 Klasický `<link rel="stylesheet">` na Google Fonts blokuje renderovanie celej stránky, kým sa font CSS nestiahne. Na pomalšom pripojení to znamená bielu obrazovku na 1-2 sekundy navyše.
 
+Aj keď sa render-blocking vyrieši cez `preload`, fonty sa stále sťahujú z externých serverov (`fonts.googleapis.com`, `fonts.gstatic.com`). Každý externý request znamená:
+
+- **DNS lookup** — prehliadač musí preložiť doménu na IP adresu
+- **TCP + TLS handshake** — nové spojenie pre každý server
+- **Žiadna kontrola nad cachingom** — Google nastavuje vlastné cache hlavičky
+
+Na mobile (simulované pomalé 4G s 150 ms RTT) to pridáva stovky milisekúnd navyše pri každom prvom načítaní.
+
+Google Fonts servuje Inter ako variable font s veľkosťou **230 KB** a JetBrains Mono **56 KB** — spolu **286 KB** cez externé servery.
+
 ### Riešenie
 
-Prvý krok — nahradil som render-blocking link za non-blocking `preload` + `onload` swap pattern:
+Stiahol som fonty a subsettoval ich pomocou `pyftsubset` (z knižnice `fonttools`) na Latin + Latin Extended-A (U+0000-017F) — pokrýva angličtinu aj slovenčinu (č, š, ž, ľ, ď, ť, ň a ďalšie).
 
-```html
-<!-- Pred: render-blocking -->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter..." />
-
-<!-- Po: non-blocking -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  rel="preload"
-  as="style"
-  href="https://fonts.googleapis.com/css2?family=Inter..."
-  onload="this.onload=null;this.rel='stylesheet'"
-/>
-<noscript>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter..." />
-</noscript>
+```bash
+pyftsubset inter-latin.woff2 \
+  --output-file=inter-latin.woff2 \
+  --flavor=woff2 \
+  --layout-features='kern,liga,clig,calt' \
+  --unicodes="U+0000-017F,U+2000-206F,U+20AC"
 ```
 
-Ako to funguje:
+Výsledné veľkosti:
 
-- `preload` stiahne CSS na pozadí bez blokovania renderu
-- `onload` po stiahnutí prepne `rel` na `stylesheet` a aplikuje fonty
-- `this.onload=null` zabráni opakovanému volaniu
-- `<noscript>` fallback pre prípad, keď je JavaScript vypnutý
+| Font | Pred (Google) | Po (subset) | Úspora |
+|------|--------------|-------------|--------|
+| Inter | 230 KB | 45 KB | –80% |
+| JetBrains Mono | 56 KB | 32 KB | –43% |
+| **Spolu** | **286 KB** | **77 KB** | **–73%** |
 
-<div class="callout note">
+V `global.css` som pridal `@font-face` deklarácie:
 
-**preconnect** otvára TCP + TLS spojenie na font server ešte pred tým, ako prehliadač vie, že bude potrebovať fonty. Ušetrí to ~100-200 ms pri prvom requeste.
+```css
+@font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 400 700;
+    font-display: swap;
+    src: url('/fonts/inter-latin.woff2') format('woff2');
+    unicode-range: U+0000-017F, U+2000-206F, U+20AC;
+}
+```
+
+A v `BaseLayout.astro` nahradil všetky Google Fonts linky jednoduchou `preload` deklaráciou:
+
+```html
+<!-- Pred: 4 linky na externé servery -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?..." onload="..." />
+<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?..." /></noscript>
+
+<!-- Po: 2 preload linky na vlastný server -->
+<link rel="preload" as="font" type="font/woff2" href="/fonts/inter-latin.woff2" crossorigin />
+<link rel="preload" as="font" type="font/woff2" href="/fonts/jetbrains-mono-latin.woff2" crossorigin />
+```
+
+<div class="callout tip">
+
+**font-display: swap** zobrazí text okamžite s fallback fontom (system-ui) a prepne na Inter/JetBrains Mono po načítaní. Používateľ vidí obsah hneď — font sa vymení bez viditeľného bliknutia.
 
 </div>
-
-Toto vyriešilo render-blocking problém, ale fonty sa stále sťahovali z externých serverov. K tomu sa vrátim v bode 4.
 
 ## 2. Farebný kontrast (WCAG)
 
@@ -155,73 +180,6 @@ To isté pre dynamické linky:
 
 Celkovo som opravil linky v 12 súboroch — homepage, blog listy, tag stránky, slug stránky a navigáciu v Header komponente.
 
-## 4. Self-hosting fontov
-
-### Problém
-
-Aj po preload optimalizácii sa fonty sťahovali z `fonts.googleapis.com` a `fonts.gstatic.com`. Každý externý request znamená:
-
-- **DNS lookup** — prehliadač musí preložiť doménu na IP adresu
-- **TCP + TLS handshake** — nové spojenie pre každý server
-- **Žiadna kontrola nad cachingom** — Google nastavuje vlastné cache hlavičky
-
-Na mobile (simulované pomalé 4G s 150 ms RTT) to pridáva stovky milisekúnd navyše pri každom prvom načítaní.
-
-Google Fonts servuje Inter ako variable font s veľkosťou **230 KB** a JetBrains Mono **56 KB** — spolu **286 KB** cez externé servery.
-
-### Riešenie
-
-Stiahol som fonty a subsettoval ich pomocou `pyftsubset` (z knižnice `fonttools`) na Latin + Latin Extended-A (U+0000-017F) — pokrýva angličtinu aj slovenčinu (č, š, ž, ľ, ď, ť, ň a ďalšie).
-
-```bash
-pyftsubset inter-latin.woff2 \
-  --output-file=inter-latin.woff2 \
-  --flavor=woff2 \
-  --layout-features='kern,liga,clig,calt' \
-  --unicodes="U+0000-017F,U+2000-206F,U+20AC"
-```
-
-Výsledné veľkosti:
-
-| Font | Pred (Google) | Po (subset) | Úspora |
-|------|--------------|-------------|--------|
-| Inter | 230 KB | 45 KB | –80% |
-| JetBrains Mono | 56 KB | 32 KB | –43% |
-| **Spolu** | **286 KB** | **77 KB** | **–73%** |
-
-V `global.css` som pridal `@font-face` deklarácie:
-
-```css
-@font-face {
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 400 700;
-    font-display: swap;
-    src: url('/fonts/inter-latin.woff2') format('woff2');
-    unicode-range: U+0000-017F, U+2000-206F, U+20AC;
-}
-```
-
-A v `BaseLayout.astro` nahradil všetky Google Fonts linky jednoduchou `preload` deklaráciou:
-
-```html
-<!-- Pred: 4 linky na externé servery -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?..." onload="..." />
-<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?..." /></noscript>
-
-<!-- Po: 2 preload linky na vlastný server -->
-<link rel="preload" as="font" type="font/woff2" href="/fonts/inter-latin.woff2" crossorigin />
-<link rel="preload" as="font" type="font/woff2" href="/fonts/jetbrains-mono-latin.woff2" crossorigin />
-```
-
-<div class="callout tip">
-
-**font-display: swap** zobrazí text okamžite s fallback fontom (system-ui) a prepne na Inter/JetBrains Mono po načítaní. Používateľ vidí obsah hneď — font sa vymení bez viditeľného bliknutia.
-
-</div>
-
 ## Výsledok
 
 <details>
@@ -253,21 +211,21 @@ npx lighthouse http://localhost:4444/en/ \
 
 Lokálne 100 nie je celý príbeh. Lighthouse na produkčnom serveri testuje s reálnou sieťovou latenciou — a mobile preset simuluje **pomalé 4G** (1.6 Mbps, 150 ms RTT).
 
-Pred self-hostingom fontov vyzerala produkcia takto:
+Pred optimalizáciou:
 
 | Preset | Performance | Accessibility | Best Practices | SEO |
 |--------|-------------|---------------|----------------|-----|
-| Desktop | 97 | 100 | 100 | 100 |
-| Mobile | 87 | 100 | 100 | 100 |
+| Desktop | 97 | 94 | 100 | 100 |
+| Mobile | 87 | 94 | 100 | 100 |
 
-Po self-hostingu a subsettingu:
+Po všetkých optimalizáciách:
 
 | Preset | Performance | Accessibility | Best Practices | SEO |
 |--------|-------------|---------------|----------------|-----|
-| Desktop | **100** | 100 | 100 | 100 |
-| Mobile | **94–95** | 100 | 100 | 100 |
+| Desktop | **100** | **100** | 100 | 100 |
+| Mobile | **94–95** | **100** | 100 | 100 |
 
-Desktop je na **100**. Mobile skočil z 87 na **94–95** — FCP klesol z 3.0 s na 1.0 s. To je obrovský rozdiel, ale stále nie 100. Prečo?
+Desktop je na **100/100/100/100**. Mobile Performance skočil z 87 na **94–95** — FCP klesol z 3.0 s na 1.0 s. Accessibility z 94 na **100**.
 
 ## Prečo mobile nie je 100 na produkcii
 
@@ -304,7 +262,6 @@ Toto sú faktory, ktoré stoja zvyšných 5–6 bodov. Na localhost (bez latenci
 | Self-hosting fontov | Eliminuje 3 externé requesty | Hotové |
 | Font subsetting | –73% veľkosť fontov (286 → 77 KB) | Hotové |
 | Trailing slash fix | Eliminuje 301 redirect (~925 ms) | Hotové |
-| Non-blocking font loading | Eliminuje render-blocking CSS | Hotové |
 | WCAG kontrast (dark + light) | 100% Accessibility | Hotové |
 | CDN (Cloudflare/Vercel) | Edge caching, dlhší cache, Brotli | Zvážiť |
 | Inline critical CSS | Eliminuje render-blocking Astro CSS | Zvážiť |


### PR DESCRIPTION
## Summary
- Restructured PageSpeed blog post — merged overlapping font sections (1+4) into single coherent section
- Added `github-pages` tag, updated title to highlight GitHub Pages limitations
- Published (draft: false) with real production Lighthouse results
- Both SK and EN versions updated